### PR TITLE
Fix inconsistent path slashes breaking seen logic

### DIFF
--- a/lib/File.js
+++ b/lib/File.js
@@ -2,6 +2,8 @@
 
 module.exports = File;
 
+var path = require('path');
+
 function File(opts) {
 	this.opts = opts;
 	this._seen = {};
@@ -33,6 +35,8 @@ File.prototype.wrap = function (src) {
 };
 
 File.prototype.seen = function (filepath) {
+    // fixes inconsistent slashes in windows paths
+    filepath = path.resolve(filepath);
 	if (this._seen[filepath]) {
 		this.debug('"' + filepath + '" skipped because it was already included.');
 		return false;

--- a/lib/GlobNode.js
+++ b/lib/GlobNode.js
@@ -4,6 +4,7 @@ module.exports = GlobNode;
 
 var glob = require('glob'),
 	q = require('q'),
+	path = require('path'),
 	FileNode = require('./FileNode');
 
 function GlobNode(globpath, file) {
@@ -22,6 +23,10 @@ function expand(node) {
 
 function findFiles(node, promise, err, files) {
 	node.nodes = files
+		.filter(function(filepath) {
+			// fixes inconsistent slashes in windows paths
+			return path.resolve(filepath);
+		})
 		.filter(node.file.seen.bind(node.file))
 		.map(filepathToFileNode.bind(null, node));
 
@@ -45,6 +50,6 @@ function nodeToString(node) {
 	return node.toString();
 }
 
-GlobNode.prototype.toString = function () {
+GlobNode.prototype.toString = function() {
 	return this.nodes.map(nodeToString).join(this.file.separator);
 };


### PR DESCRIPTION
Fixes #8
On windows machines, globs return paths with backslashes, but filepaths
are represented with forward slashes.  This breaks the "seen" tracking,
as `d:\some\path` obviously won't match `d:/some/path`.  Use `path.resolve()`
in the File's `seen` method to normalize slashes in paths before
checking against the "seen" hash, and do the same in the GlobNode's
`findFiles` method.
